### PR TITLE
docs: 修复 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,5 +523,5 @@ stdout_logfile=/tmp/blog_stdout.log
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Allen7D/mini-shop-server&type=Date)](https://star-history.com/#Allen7D/mini-shop-server&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Allen7D/mini-shop-server&type=Date)](https://star-history.dera.page/#Allen7D/mini-shop-server&Date)
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub stargazer API 限制而无法正常显示，需要修复。本 PR 将图表链接切换到新的数据源，恢复 Star History 图表的正常展示。